### PR TITLE
update dependency @octokit/rest to v17

### DIFF
--- a/tools/update-schema/package.json
+++ b/tools/update-schema/package.json
@@ -10,7 +10,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@octokit/rest": "^16.16.0",
+    "@octokit/rest": "17.0.0",
     "request": "^2.88.0",
     "rimraf": "^2.6.3",
     "tl-to-json": "1.0.0"


### PR DESCRIPTION
Follow Up #77
Based on the information that was available [here](https://github.com/octokit/octokit.js/issues/1624#issuecomment-589796534).